### PR TITLE
Remove extra space before commas in the interests section

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -297,16 +297,16 @@
       {{#each resume.interests}}
       <span class='name'>{{name}}</span><!--
       {{#if keywords.length}}
-      --><span class='keywords'><em>[
+      --><span class='keywords'> <em>[
       {{#each keywords}} 
-        {{.}}
-        {{#unless @last}}, {{/unless}}
+        {{.}}<!--
+        -->{{#unless @last}}, {{/unless}}
       {{/each}}
       ]</em></span><!--
       {{/if}}
-      {{#unless @last}}--><span>, </span>{{/unless}}
+      -->{{#unless @last}}<span>, </span>{{/unless}}
       {{/each}}
-    --></div>
+    </div>
     <div class='sectionLine'></div>
 	</div>
   {{/if}}

--- a/resume.hbs
+++ b/resume.hbs
@@ -15,7 +15,6 @@
 	<body>
 	
 	<div id='resume'>
-
 	{{#resume.basics}}
   <div id='nameBlock' class='largeFont'>
     <span class='name'>
@@ -296,18 +295,18 @@
     </div>
     <div class='sectionContent'>
       {{#each resume.interests}}
-      <span class='name'>{{name}}</span>
+      <span class='name'>{{name}}</span><!--
       {{#if keywords.length}}
-      <span class='keywords'><em>[
+      --><span class='keywords'><em>[
       {{#each keywords}} 
         {{.}}
         {{#unless @last}}, {{/unless}}
       {{/each}}
-      ]</em></span>
+      ]</em></span><!--
       {{/if}}
-      {{#unless @last}}<span>,</span>{{/unless}}
+      {{#unless @last}}--><span>, </span>{{/unless}}
       {{/each}}
-    </div>
+    --></div>
     <div class='sectionLine'></div>
 	</div>
   {{/if}}


### PR DESCRIPTION
This pull request removes extra spaces before the names and keywords of interests. I think the commits say the skills section, but its for the interest section.

What I mean is that this:

```
Photography [ Travel , Landscape ] , Travel , Motorsports
```

becomes this:

```
Photography [ Travel, Landscape ], Travel, Motorsports
```
