### PR TITLE
Add title for education

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -219,6 +219,9 @@
         <span class='title'>
           {{#if institution}}{{institution}}{{/if}}
         </span>
+        <span class='education-title'>
+          {{#if title}}{{title}}{{/if}}
+        </span>
         {{#if startDate}}
         <span class='date'>
           {{#if startDate}}{{startDate}}{{/if}}{{#if endDate}}-{{endDate}}{{else}}Present{{/if}}


### PR DESCRIPTION
Right now, only the `institution` is shown, but I'd like to see the course as well :+1: 
