### PR TITLE
Add website to Basics section

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -39,6 +39,10 @@
           {{#if city}}{{city}}{{/if}}{{#if region}}, {{region}}{{/if}}{{#if countryCode}}, {{countryCode}}{{/if}}
         </span>
       {{/location}}
+       {{#if website}}
+      <span class='divider'>|</span>
+      <span class='website'>{{website}}</span>
+      {{/if}}
     </div>
     {{#if profiles.length}}
       <div id='profilesBlock'>


### PR DESCRIPTION
Given the importance of a professional website to a tech person, I propose adding it to the basics section should it exist. The workaround for this theme is to add a new profile entry, but I think that it would work better as part of the basics section given that the jsonresume schema includes `website`.