### PR TITLE
Let include HTML on basic summary

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -62,7 +62,7 @@
       <span>SUMMARY</span>
     </div>
     <div class='sectionContent'>
-      <span>{{resume.basics.summary}}</span>
+      {{{resume.basics.summary}}}
     </div>
   </div>
   <div class='sectionLine'></div>


### PR DESCRIPTION
Use triple anchor to let include HTML inside the basic summary.

It helps to format long summary (sounds contradictory, I know).